### PR TITLE
Serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ memmap2 = "0.5.7"
 once_cell = "1.16.0"
 procmaps = "0.4.1"
 rustc-demangle = "0.1.21"
+serde = "1.0"
 thiserror = "1.0.37"
 itertools = "0.10.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,5 @@ itertools = "0.10.5"
 [dev-dependencies]
 quickcheck = "1.0"
 quickcheck_macros = "1.0"
+serde_derive = "1.0.151"
+serde_json = "1.0.11"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -326,6 +326,18 @@ impl fmt::Debug for dyn Reflect {
     }
 }
 
+impl serde::Serialize for dyn Reflect + '_
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let context = default_provider().map_err(crate::ser_err)?;
+        let value = self.reflect(&context).map_err(crate::ser_err)?;
+        value.serialize(serializer)
+    }
+}
+
 macro_rules! generate_type_and_value {
     ($($(#[$attr:meta])* $t:ident,)*) => {
         /// A reflected type.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 //!
 //! // initialize the debuginfo provider
 //! let context = deflect::default_provider()?;
-//! 
+//!
 //! // create some type-erased data
 //! let erased: Box<dyn Any> = Box::new(Foo { a: 42 });
 //!
@@ -30,27 +30,27 @@
 //!
 //! // pretty-print the reflected value
 //! assert_eq!(value.to_string(), "box Foo { a: 42 }");
-//! 
+//!
 //! // downcast into a `BoxedDyn` value
 //! let value: deflect::value::BoxedDyn = value.try_into()?;
 //!
 //! // dereference the boxed value
 //! let value: deflect::Value = value.deref()?;
-//! 
+//!
 //! // downcast into a `Struct` value
 //! let value: deflect::value::Struct = value.try_into()?;
-//! 
+//!
 //! // get the field `a` by name
 //! let Some(field) = value.field("a")? else {
 //!     panic!("no field named `a`!")
 //! };
-//! 
+//!
 //! // get the value of the field
 //! let value = field.value()?;
-//! 
+//!
 //! // downcast into a `u8`
 //! let value: u8 = value.try_into()?;
-//! 
+//!
 //! // check that it's equal to `42`!
 //! assert_eq!(value, 42);
 //! # Ok::<_, Box<dyn std::error::Error>>(())
@@ -256,6 +256,7 @@ pub trait Reflect {
     }
 }
 
+// Implement `Reflect` for ALL types.
 impl<T: ?Sized> Reflect for T {}
 
 impl dyn Reflect + '_ {
@@ -456,6 +457,20 @@ macro_rules! generate_type_and_value {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 match self {
                     $(Self::$t(v) => v.fmt(f),)*
+                }
+            }
+        }
+
+        impl<'value, 'dwarf, P> serde::Serialize for Value<'value, 'dwarf, P>
+        where
+            P: crate::DebugInfoProvider,
+        {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                match self {
+                    $(Self::$t(v) => v.serialize(serializer),)*
                 }
             }
         }
@@ -794,4 +809,11 @@ where
 fn fmt_err<E: fmt::Display>(err: E) -> fmt::Error {
     eprintln!("ERROR: {err}");
     fmt::Error
+}
+
+fn ser_err<E>(e: impl ToString) -> E
+where
+    E: serde::ser::Error,
+{
+    E::custom(e.to_string())
 }

--- a/src/schema/variant.rs
+++ b/src/schema/variant.rs
@@ -11,6 +11,7 @@ where
     unit: &'dwarf crate::gimli::Unit<R, usize>,
     entry: crate::gimli::DebuggingInformationEntry<'dwarf, 'dwarf, R>,
     discriminant_val: Option<super::Data>,
+    index: usize,
 }
 
 impl<'dwarf, R> Variant<'dwarf, R>
@@ -22,12 +23,14 @@ where
         unit: &'dwarf crate::gimli::Unit<R, usize>,
         entry: crate::gimli::DebuggingInformationEntry<'dwarf, 'dwarf, R>,
         discriminant_val: Option<super::Data>,
+        index: usize,
     ) -> Self {
         Self {
             dwarf,
             unit,
             entry,
             discriminant_val,
+            index,
         }
     }
 
@@ -82,6 +85,11 @@ where
     pub fn fields(&self) -> Result<super::Fields<'dwarf, R>, crate::Error> {
         let tree = self.unit.entries_tree(Some(self.entry.offset()))?;
         Ok(super::Fields::from_tree(self.dwarf, self.unit, tree))
+    }
+
+    /// The index of the variant.
+    pub fn index(&self) -> usize {
+        self.index
     }
 }
 

--- a/src/value/box.rs
+++ b/src/value/box.rs
@@ -89,3 +89,16 @@ where
         self.deref().map_err(crate::fmt_err)?.fmt(f)
     }
 }
+
+impl<'value, 'dwarf, P> serde::Serialize for Box<'value, 'dwarf, P>
+where
+    P: crate::DebugInfoProvider,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.deref().map_err(crate::ser_err)?;
+        value.serialize(serializer)
+    }
+}

--- a/src/value/boxed_dyn.rs
+++ b/src/value/boxed_dyn.rs
@@ -38,7 +38,7 @@ where
     pub fn schema(&self) -> &crate::schema::BoxedDyn<'dwarf, P::Reader> {
         &self.schema
     }
-    
+
     fn data(&self, size: usize) -> Result<crate::Bytes<'value>, crate::Error> {
         let field =
             unsafe { super::Field::new(self.schema.pointer().clone(), self.value, self.provider) };
@@ -106,5 +106,18 @@ where
         let value = self.deref().map_err(crate::fmt_err)?;
         f.write_str("box ")?;
         value.fmt(f)
+    }
+}
+
+impl<'value, 'dwarf, P> serde::Serialize for BoxedDyn<'value, 'dwarf, P>
+where
+    P: crate::DebugInfoProvider,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.deref().map_err(crate::ser_err)?;
+        value.serialize(serializer)
     }
 }

--- a/src/value/boxed_slice.rs
+++ b/src/value/boxed_slice.rs
@@ -102,3 +102,22 @@ where
         f.write_str("[..]")
     }
 }
+
+impl<'value, 'dwarf, P> serde::Serialize for BoxedSlice<'value, 'dwarf, P>
+where
+    P: crate::DebugInfoProvider,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeSeq;
+        let len = Some(self.length().map_err(crate::ser_err)?);
+        let mut ser_seq = serializer.serialize_seq(len).map_err(crate::ser_err)?;
+        for maybe_elt in self.iter().map_err(crate::ser_err)? {
+            let elt = maybe_elt.map_err(crate::ser_err)?;
+            ser_seq.serialize_element(&elt)?
+        }
+        ser_seq.end()
+    }
+}

--- a/src/value/function.rs
+++ b/src/value/function.rs
@@ -58,3 +58,14 @@ where
     }
 }
 
+impl<'value, 'dwarf, P> serde::Serialize for Function<'value, 'dwarf, P>
+where
+    P: crate::DebugInfoProvider,
+{
+    fn serialize<S>(&self, _: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        Err(crate::ser_err("cannot serialize function"))
+    }
+}

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -207,6 +207,18 @@ macro_rules! generate_primitive {
             }
         }
 
+        impl<'value, 'dwarf, P> serde::Serialize for $t<'value, 'dwarf, P>
+        where
+            P: crate::DebugInfoProvider,
+        {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                self.value().serialize(serializer)
+            }
+        }
+
         generate_primitive_conversions!($t);
     };
 }
@@ -358,5 +370,17 @@ where
         } else {
             Err(crate::DowncastErr::new::<Value<'value, 'dwarf, P>, Self>())
         }
+    }
+}
+
+impl<'value, 'dwarf, P> serde::Serialize for unit<'value, 'dwarf, P>
+where
+    P: crate::DebugInfoProvider,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.value().serialize(serializer)
     }
 }

--- a/src/value/pointer.rs
+++ b/src/value/pointer.rs
@@ -135,3 +135,52 @@ where
     }
 }
 
+impl<'value, 'dwarf, P> serde::Serialize for Pointer<'value, 'dwarf, crate::schema::Shared, P>
+where
+    P: crate::DebugInfoProvider,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.deref().map_err(crate::ser_err)?;
+        value.serialize(serializer)
+    }
+}
+
+impl<'value, 'dwarf, P> serde::Serialize for Pointer<'value, 'dwarf, crate::schema::Unique, P>
+where
+    P: crate::DebugInfoProvider,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let value = self.deref().map_err(crate::ser_err)?;
+        value.serialize(serializer)
+    }
+}
+
+impl<'value, 'dwarf, P> serde::Serialize for Pointer<'value, 'dwarf, crate::schema::Const, P>
+where
+    P: crate::DebugInfoProvider,
+{
+    fn serialize<S>(&self, _: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        Err(crate::ser_err("cannot serialize *const pointer"))
+    }
+}
+
+impl<'value, 'dwarf, P> serde::Serialize for Pointer<'value, 'dwarf, crate::schema::Mut, P>
+where
+    P: crate::DebugInfoProvider,
+{
+    fn serialize<S>(&self, _: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        Err(crate::ser_err("cannot serialize *mut pointer"))
+    }
+}

--- a/src/value/slice_impl.rs
+++ b/src/value/slice_impl.rs
@@ -101,3 +101,22 @@ where
         debug_list.finish()
     }
 }
+
+impl<'value, 'dwarf, P> serde::Serialize for Slice<'value, 'dwarf, P>
+where
+    P: crate::DebugInfoProvider,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeSeq;
+        let len = Some(self.length().map_err(crate::ser_err)?);
+        let mut ser_seq = serializer.serialize_seq(len).map_err(crate::ser_err)?;
+        for maybe_elt in self.iter().map_err(crate::ser_err)? {
+            let elt = maybe_elt.map_err(crate::ser_err)?;
+            ser_seq.serialize_element(&elt)?;
+        }
+        ser_seq.end()
+    }
+}

--- a/src/value/str_impl.rs
+++ b/src/value/str_impl.rs
@@ -79,6 +79,18 @@ where
     }
 }
 
+impl<'value, 'dwarf, P> serde::Serialize for str<'value, 'dwarf, P>
+where
+    P: crate::DebugInfoProvider,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.value().serialize(serializer)
+    }
+}
+
 impl<'value, 'dwarf, P> From<str<'value, 'dwarf, P>> for &'value std::primitive::str
 where
     P: crate::DebugInfoProvider,

--- a/tests/reflect.rs
+++ b/tests/reflect.rs
@@ -1,5 +1,19 @@
 use std::fmt;
+
 struct DisplayDebug<T>(T);
+
+#[track_caller]
+fn assert_ser_eq<T, U>(lhs: T, rhs: U) -> Result<(), serde_json::error::Error>
+where
+    T: serde::Serialize,
+    U: serde::Serialize,
+{
+    let lhs = serde_json::to_value(lhs)?;
+    let rhs = serde_json::to_value(rhs)?;
+
+    assert_eq!(lhs, rhs);
+    Ok(())
+}
 
 impl<T> fmt::Display for DisplayDebug<T>
 where
@@ -18,6 +32,8 @@ fn phantom_data() -> Result<(), Box<dyn std::error::Error>> {
     let value = erased.reflect(&context)?;
     let value: deflect::value::Struct<_> = value.try_into()?;
     assert_eq!(value.to_string(), "PhantomData<usize>");
+
+
     Ok(())
 }
 
@@ -43,6 +59,7 @@ fn tuple_struct() -> Result<(), Box<dyn std::error::Error>> {
 
 #[test]
 fn braced_struct() -> Result<(), Box<dyn std::error::Error>> {
+    #[derive(serde_derive::Serialize)]
     struct BracedStruct {
         #[allow(dead_code)]
         foo: u8,
@@ -51,6 +68,7 @@ fn braced_struct() -> Result<(), Box<dyn std::error::Error>> {
     let context = deflect::default_provider()?;
     let value = erased.reflect(&context)?;
     assert_eq!(value.to_string(), "BracedStruct { foo: 42 }");
+    assert_ser_eq(erased, &BracedStruct { foo: 42 })?;
     Ok(())
 }
 
@@ -87,6 +105,7 @@ mod slice {
             .try_collect()?;
 
         assert_eq!(data, collected);
+        crate::assert_ser_eq(erased, slice)?;
 
         Ok(())
     }
@@ -109,6 +128,7 @@ mod slice {
             .try_collect()?;
 
         assert_eq!(data, collected);
+        crate::assert_ser_eq(erased, slice)?;
 
         Ok(())
     }
@@ -122,6 +142,7 @@ fn str(data: String) -> Result<(), Box<dyn std::error::Error>> {
     let value = erased.reflect(&context)?;
     let value: &str = value.try_into()?;
     assert_eq!(slice, value);
+    crate::assert_ser_eq(erased, slice)?;
     Ok(())
 }
 
@@ -159,6 +180,7 @@ fn boxed_slice() -> Result<(), Box<dyn std::error::Error>> {
     let value: deflect::Value = erased.reflect(&context)?;
     let value: deflect::value::BoxedSlice = value.try_into()?;
     assert_eq!(value.to_string(), "box [1, 2, 3][..]");
+    crate::assert_ser_eq(erased, &data)?;
     Ok(())
 }
 
@@ -189,6 +211,7 @@ mod primitive {
             &n,
             <&_>::try_from(value).expect("failed to downcast")
         ));
+        crate::assert_ser_eq(erased, &n)?;
         Ok(())
     }
 
@@ -202,6 +225,7 @@ mod primitive {
             &n,
             <&_>::try_from(value).expect("failed to downcast")
         ));
+        crate::assert_ser_eq(erased, &n)?;
         Ok(())
     }
 
@@ -215,6 +239,7 @@ mod primitive {
             &n,
             <&_>::try_from(value).expect("failed to downcast")
         ));
+        crate::assert_ser_eq(erased, &n)?;
         Ok(())
     }
 
@@ -228,6 +253,7 @@ mod primitive {
             &n,
             <&_>::try_from(value).expect("failed to downcast")
         ));
+        crate::assert_ser_eq(erased, &n)?;
         Ok(())
     }
 
@@ -241,6 +267,7 @@ mod primitive {
             &n,
             <&_>::try_from(value).expect("failed to downcast")
         ));
+        crate::assert_ser_eq(erased, &n)?;
         Ok(())
     }
 
@@ -254,6 +281,7 @@ mod primitive {
             &n,
             <&_>::try_from(value).expect("failed to downcast")
         ));
+        crate::assert_ser_eq(erased, &n)?;
         Ok(())
     }
 
@@ -267,6 +295,7 @@ mod primitive {
             &n,
             <&_>::try_from(value).expect("failed to downcast")
         ));
+        crate::assert_ser_eq(erased, &n)?;
         Ok(())
     }
 
@@ -280,6 +309,7 @@ mod primitive {
             &n,
             <&_>::try_from(value).expect("failed to downcast")
         ));
+        crate::assert_ser_eq(erased, &n)?;
         Ok(())
     }
 
@@ -306,6 +336,7 @@ mod primitive {
             &n,
             <&_>::try_from(value).expect("failed to downcast")
         ));
+        crate::assert_ser_eq(erased, &n)?;
         Ok(())
     }
 
@@ -319,6 +350,7 @@ mod primitive {
             &n,
             <&_>::try_from(value).expect("failed to downcast")
         ));
+        crate::assert_ser_eq(erased, &n)?;
         Ok(())
     }
 
@@ -332,6 +364,7 @@ mod primitive {
             &n,
             <&_>::try_from(value).expect("failed to downcast")
         ));
+        crate::assert_ser_eq(erased, &n)?;
         Ok(())
     }
 
@@ -345,6 +378,7 @@ mod primitive {
             &n,
             <&_>::try_from(value).expect("failed to downcast")
         ));
+        crate::assert_ser_eq(erased, &n)?;
         Ok(())
     }
 
@@ -358,6 +392,7 @@ mod primitive {
             &n,
             <&_>::try_from(value).expect("failed to downcast")
         ));
+        crate::assert_ser_eq(erased, &n)?;
         Ok(())
     }
 
@@ -384,6 +419,7 @@ mod primitive {
             &n,
             <&_>::try_from(value).expect("failed to downcast")
         ));
+        crate::assert_ser_eq(erased, &n)?;
         Ok(())
     }
 }


### PR DESCRIPTION
still todo:
- [ ] make it an optional feature to reduce bloat
- [ ] use field-name heuristics to select between `serialize_struct` and `serialize_tuple_struct`
- [ ] tests!